### PR TITLE
Feature: introduction text for payment method

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -103,7 +103,15 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
 
     public function getConfig()
     {
-        $description = __("Information on the processing of your personal data by Mondu GmbH can be found <a href='https://www.mondu.ai/de/datenschutzgrundverordnung-kaeufer/' target='_blank'>here.</a>");
+        $privacyText = __("Information on the processing of your personal data by Mondu GmbH can be found <a href='https://www.mondu.ai/de/datenschutzgrundverordnung-kaeufer/' target='_blank'>here.</a>");
+        $descriptionConfigMondu = $this->scopeConfig->getValue('payment/mondu/description');
+        $descriptionConfigMondusepa = $this->scopeConfig->getValue('payment/mondusepa/description');
+        $descriptionConfigMonduinstallment = $this->scopeConfig->getValue('payment/monduinstallment/description');
+        
+        $descriptionMondu = $descriptionConfigMondu ? __($descriptionConfigMondu) . '<br><br>' . $privacyText : $privacyText;
+        $descriptionMondusepa = $descriptionConfigMondusepa ? __($descriptionConfigMondusepa) . '<br><br>' . $privacyText : $privacyText;
+        $descriptionMonduinstallment = $descriptionConfigMonduinstallment ? __($descriptionConfigMonduinstallment) . '<br><br>' . $privacyText : $privacyText;
+        
         return [
             'payment' => [
                 self::CODE => [
@@ -113,19 +121,19 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
                         ClientMock::FAILURE => __('Fraud'),
                     ],
                     'monduCheckoutTokenUrl' => $this->urlBuilder->getUrl('mondu/payment_checkout/token'),
-                    'description' => __($description),
+                    'description' => $descriptionMondu,
                     'title' => __($this->scopeConfig->getValue('payment/mondu/title'))
                 ],
                 'mondusepa' => [
                     'sdkUrl' => $this->getSdkUrl(),
                     'monduCheckoutTokenUrl' => $this->urlBuilder->getUrl('mondu/payment_checkout/token'),
-                    'description' => __($description),
+                    'description' => $descriptionMondusepa,
                     'title' => __($this->scopeConfig->getValue('payment/mondusepa/title'))
                 ],
                 'monduinstallment' => [
                     'sdkUrl' => $this->getSdkUrl(),
                     'monduCheckoutTokenUrl' => $this->urlBuilder->getUrl('mondu/payment_checkout/token'),
-                    'description' => __($description),
+                    'description' => $descriptionMonduinstallment,
                     'title' => __($this->scopeConfig->getValue('payment/monduinstallment/title'))
                 ]
             ]

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -8,6 +8,7 @@ use Mondu\Mondu\Gateway\Http\Client\ClientMock;
 use Magento\Config\Model\ResourceModel\Config as ResourceConfig;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
 {
@@ -104,9 +105,9 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
     public function getConfig()
     {
         $privacyText = __("Information on the processing of your personal data by Mondu GmbH can be found <a href='https://www.mondu.ai/de/datenschutzgrundverordnung-kaeufer/' target='_blank'>here.</a>");
-        $descriptionConfigMondu = $this->scopeConfig->getValue('payment/mondu/description');
-        $descriptionConfigMondusepa = $this->scopeConfig->getValue('payment/mondusepa/description');
-        $descriptionConfigMonduinstallment = $this->scopeConfig->getValue('payment/monduinstallment/description');
+        $descriptionConfigMondu = $this->scopeConfig->getValue('payment/mondu/description', ScopeInterface::SCOPE_STORE);
+        $descriptionConfigMondusepa = $this->scopeConfig->getValue('payment/mondusepa/description', ScopeInterface::SCOPE_STORE);
+        $descriptionConfigMonduinstallment = $this->scopeConfig->getValue('payment/monduinstallment/description', ScopeInterface::SCOPE_STORE);
         
         $descriptionMondu = $descriptionConfigMondu ? __($descriptionConfigMondu) . '<br><br>' . $privacyText : $privacyText;
         $descriptionMondusepa = $descriptionConfigMondusepa ? __($descriptionConfigMondusepa) . '<br><br>' . $privacyText : $privacyText;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -50,53 +50,67 @@
                         <label>Bank Transfer Title</label>
                         <config_path>payment/mondu/title</config_path>
                     </field>
-                    <field id="activesepa" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+                    <field id="description" translate="label" type="textarea" sortOrder="3" showInDefault="1" showInWebsite="1"
+                           showInStore="1">
+                        <label>Bank Transfer Description</label>
+                        <config_path>payment/mondu/description</config_path>
+                    </field>
+                    <field id="activesepa" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>Enable SEPA Direct Debit</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondusepa/active</config_path>
                     </field>
-
-                    <field id="sepa_title" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1"
+                    <field id="sepa_title" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>SEPA Direct Debit Title</label>
                         <config_path>payment/mondusepa/title</config_path>
                     </field>
-                    <field id="activeinstallment" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
+                    <field id="sepa_description" translate="label" type="textarea" sortOrder="6" showInDefault="1" showInWebsite="1"
+                           showInStore="1">
+                        <label>SEPA Direct Debit Description</label>
+                        <config_path>payment/mondusepa/description</config_path>
+                    </field>
+                    <field id="activeinstallment" translate="label" type="select" sortOrder="7" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>Enable Split Payments</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/monduinstallment/active</config_path>
                     </field>
-                    <field id="installment_title" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1"
+                    <field id="installment_title" translate="label" type="text" sortOrder="8" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>Split Payments Title</label>
                         <config_path>payment/monduinstallment/title</config_path>
                     </field>
-                    <field id="order_status" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" canRestore="1">
+                    <field id="installment_description" translate="label" type="textarea" sortOrder="9" showInDefault="1" showInWebsite="1"
+                           showInStore="1">
+                        <label>Split Payments Description</label>
+                        <config_path>payment/monduinstallment/description</config_path>
+                    </field>
+                    <field id="order_status" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" canRestore="1">
                         <label>New Order Status</label>
                         <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
                         <config_path>payment/mondu/order_status</config_path>
                     </field>
-                    <field id="allowspecific" translate="label" type="allowspecific" sortOrder="7" showInDefault="9"
+                    <field id="allowspecific" translate="label" type="allowspecific" sortOrder="11" showInDefault="9"
                            showInWebsite="1" showInStore="1">
                         <label>Payment From Applicable Countries</label>
                         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                         <config_path>payment/mondu/allowspecific</config_path>
                     </field>
-                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="8" showInDefault="1"
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="12" showInDefault="1"
                            showInWebsite="1" showInStore="1">
                         <label>Payment From Specific Countries</label>
                         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                         <config_path>payment/mondu/specificcountry</config_path>
                     </field>
-                    <field id="cron" translate="label" type="select" sortOrder="11" showInDefault="1" showInWebsite="1"
+                    <field id="cron" translate="label" type="select" sortOrder="13" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>Enable automatic order processing</label>
                         <config_path>payment/mondu/cron</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
-                    <field id="debug" translate="label" type="select" sortOrder="12" showInDefault="1" showInWebsite="1"
+                    <field id="debug" translate="label" type="select" sortOrder="14" showInDefault="1" showInWebsite="1"
                            showInStore="1">
                         <label>Enable Logs</label>
                         <config_path>payment/mondu/debug</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
                 <mondu_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <order_status>pending</order_status>
                 <title>Pay later via bank transfer</title>
-                <description>Hinweise zur Verarbeitung Ihrer personenbezogenen Daten durch die Mondu GmbH finden Sie hier.</description>
+                <description></description>
                 <sandbox>1</sandbox>
                 <cron>0</cron>
                 <allowspecific>1</allowspecific>
@@ -26,7 +26,7 @@
                 <debug>1</debug>
                 <model>Mondu\Mondu\Model\Payment\MonduSepa</model>
                 <order_status>pending</order_status>
-                <description>Hinweise zur Verarbeitung Ihrer personenbezogenen Daten durch die Mondu GmbH finden Sie hier.</description>
+                <description></description>
                 <title>Pay later via SEPA Direct Debit</title>
             </mondusepa>
             <monduinstallment>
@@ -35,7 +35,7 @@
                 <debug>1</debug>
                 <model>Mondu\Mondu\Model\Payment\MonduInstallment</model>
                 <order_status>pending</order_status>
-                <description>Hinweise zur Verarbeitung Ihrer personenbezogenen Daten durch die Mondu GmbH finden Sie hier.</description>
+                <description></description>
                 <title>Split Payments</title>
             </monduinstallment>
         </payment>


### PR DESCRIPTION
### Description of feature

At the moment when you choose Mondu payment method, you have only some additional sentence about privacy policy. But there is no possibility to add some instruction information what Mondu is and what the user should do. Also such an introduction text is easy to use to explain, that Mondu is some B2B only payment method.

This PR adds some store view based config for all three Mondu payment methods to add an introduction text next before the privacy text separated by a blank line. If there is no config, only the privacy text is shown for legal reasons like now.


### Additional fixes of code

In the original code, the phrase out of default config `payment/mondu*/description` set via `config.xml` was never used and there was no config in the Magento adminhtml. Furthermore in `ConfigProvider::getConfig()` privacy sentence translation of `$description` was translated twice. This PR fixes this.

Furthermore this PR clean up `sortOrder` of Mondu adminhtml configs in `system.xml`.

On top of this this PR remove the default value of `payment/mondu*/description` in `config.xml` because it's not used at the moment, the hyperlink on this privacy text is missing and it would result in double show by default with this new implementation. 


### Possible enhancement: default config

This PR translates `$descriptionConfigMondu`, `$descriptionConfigMondusepa` and `$descriptionConfigMonduinstallment` to be able to add a default config via `config.xml` again that we can translate via CSV in the future. As config I suggest the following:

**`payment/mondu/description`**
| language | description text | 
| --------- | ---------------- |
| Default | Mondu is a payment method special for business customers like companies, authorities and associations. With Mondu you can pay the bill within 30 days via bank transfer. |
| de | Mondu ist ein Zahlungsmittel speziell für Geschäftskunden wie Unternehmen, Behörden und Vereine. Bei Mondu können Sie die Rechnung innerhalb von 30 Tagen per Banküberweisung bezahlen. |
| nl |  Mondu is een betaalmethode speciaal voor zakelijke klanten zoals bedrijven, overheden en verenigingen. Bij Mondu kunt u de rekening binnen 30 dagen betalen via overschrijving. |


**`payment/mondusepa/description`**
| language | description text | 
| --------- | ---------------- |
| Default | Mondu is a payment method special for business customers like companies, authorities and associations. With Mondu SEPA the bill will be payed via SEPA Direct Debit. |
| de | Mondu ist ein Zahlungsmittel speziell für Geschäftskunden wie Unternehmen, Behörden und Vereine. Bei Mondu SEPA wird die Rechnung per SEPA-Lastschriftverfahren beglichen. |
| nl | Mondu is een betaalmethode speciaal voor zakelijke klanten zoals bedrijven, overheden en verenigingen. Bij Mondu SEPA wordt de rekening betaald via SEPA Direct Debit. |


**`payment/monduinstallment/description`**
| language | description text | 
| --------- | ---------------- |
| Default | Mondu is a payment method special for business customers like companies, authorities and associations. With Mondu Split Payments you can pay the bill within multiple rates. |
| de | Mondu ist ein Zahlungsmittel speziell für Geschäftskunden wie Unternehmen, Behörden und Vereine. Mit Mondu Split Payments können Sie die Rechnung in mehreren Raten bezahlen. |
| nl | Mondu is een betaalmethode speciaal voor zakelijke klanten zoals bedrijven, overheden en verenigingen. Met Mondu Split Payments kunt u de rekening binnen meerdere tarieven betalen. |


### Confusion during development

To make it possible to work with different store views, I had to add `ScopeInterface::SCOPE_STORE` as 2nd param to `$this->scopeConfig->getValue()` because otherwise it would get the config value out of default scope. Until now I do not understand, why your original code does not need `ScopeInterface::SCOPE_STORE` too when you read the config. So please check my 2nd commit 43dc92b244680373fe184f53707c822ea99a9ef1
