### PR TITLE
Avoid deprecation warning on json_decode

### DIFF
--- a/Model/Request/CommonRequest.php
+++ b/Model/Request/CommonRequest.php
@@ -68,7 +68,7 @@ abstract class CommonRequest implements RequestInterface {
             $curlData = [
                 'response_status' => (string) $this->curl->getStatus(),
                 'response_body' => json_decode($this->curl->getBody(), true) ?? [],
-                'request_body' => json_decode($this->requestParams, true) ?? [],
+                'request_body' => json_decode($this->requestParams ?? '', true) ?? [],
                 'origin_event' => $this->requestOrigin
             ];
 


### PR DESCRIPTION
## Description

Sometimes in our logs we see a deprecation warning so we integrate this patch to avoid it.

`
Exception: Deprecated Functionality: json_decode(): Passing null to parameter #1 (closed) ($json) of type string is deprecated in /path/to/magento/vendor/mondu/magento2-payment/Model/Request/CommonRequest.php on line 71 in /path/to/magento/vendor/magento/framework/App/ErrorHandler.php:62
`

## Release information

Release: -

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works
