### PR TITLE
Remove inexistent order canceled webhook

### DIFF
--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -134,7 +134,11 @@ class Index extends Action implements ActionInterface
         if (empty($order->getData())) {
             return [['message' => 'Order does not exist', 'error' => 0], 200];
         }
+        $order->setState(Order::STATE_PAYMENT_REVIEW);
         $order->setStatus(Order::STATE_PAYMENT_REVIEW);
+        $order->addStatusHistoryComment(
+            __('Mondu: Order Status changed to Payment Review by a webhook')
+        );
         $order->save();
         $this->_monduLogger->updateLogMonduData($monduId, $params['order_state']);
 
@@ -163,7 +167,11 @@ class Index extends Action implements ActionInterface
             return [['message' => 'Order does not exist', 'error' => 0], 200];
         }
 
+        $order->setState(Order::STATE_PROCESSING);
         $order->setStatus(Order::STATE_PROCESSING);
+        $order->addStatusHistoryComment(
+            __('Mondu: Order Status changed to Processing by a webhook')
+        );
         $order->save();
         $this->_monduLogger->updateLogMonduData($monduId, $params['order_state'], $viban);
 
@@ -191,6 +199,10 @@ class Index extends Action implements ActionInterface
         if (empty($order->getData())) {
             return [['message' => 'Order does not exist', 'error' => 0], 200];
         }
+
+        $order->addStatusHistoryComment(
+            __('Mondu: Order has been declined')
+        );
 
         if ($orderState === 'canceled') {
             $order->setStatus(Order::STATE_CANCELED)->save();

--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -134,7 +134,8 @@ class Index extends Action implements ActionInterface
         if (empty($order->getData())) {
             return [['message' => 'Order does not exist', 'error' => 0], 200];
         }
-
+        $order->setStatus(Order::STATE_PAYMENT_REVIEW);
+        $order->save();
         $this->_monduLogger->updateLogMonduData($monduId, $params['order_state']);
 
         return [['message' => 'ok', 'error' => 0], 200];
@@ -162,6 +163,8 @@ class Index extends Action implements ActionInterface
             return [['message' => 'Order does not exist', 'error' => 0], 200];
         }
 
+        $order->setStatus(Order::STATE_PROCESSING);
+        $order->save();
         $this->_monduLogger->updateLogMonduData($monduId, $params['order_state'], $viban);
 
         return [['message' => 'ok', 'error' => 0], 200];

--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -77,7 +77,7 @@ class Index extends Action implements ActionInterface
 
         try {
             $content = $this->getRequest()->getContent();
-            
+
             $headers = $this->getRequest()->getHeaders()->toArray();
             $signature = hash_hmac('sha256', $content, $this->_monduConfig->getWebhookSecret());
             if ($signature !== ($headers['X-Mondu-Signature'] ?? null)) {
@@ -94,7 +94,6 @@ class Index extends Action implements ActionInterface
                 case 'order/pending':
                     [$resBody, $resStatus] = $this->handlePending($params);
                     break;
-                case 'order/canceled':
                 case 'order/declined':
                     [$resBody, $resStatus] = $this->handleDeclinedOrCanceled($params);
                     break;

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -101,7 +101,7 @@ class ConfigProvider implements ConfigProviderInterface
         return $baseUrl . ($path ? '/'.$path : '');
     }
 
-        /**
+    /**
      * Returns mondu.js url
      *
      * @return string

--- a/Observer/AfterPlaceOrder.php
+++ b/Observer/AfterPlaceOrder.php
@@ -1,0 +1,53 @@
+<?php
+namespace Mondu\Mondu\Observer;
+
+use Magento\Framework\Event\Observer;
+use Mondu\Mondu\Helpers\ContextHelper;
+use Mondu\Mondu\Helpers\Logger\Logger;
+use Mondu\Mondu\Helpers\PaymentMethod;
+
+class AfterPlaceOrder extends MonduObserver
+{
+    /**
+     * @var \Mondu\Mondu\Helpers\Log
+     */
+    protected $monduLogger;
+
+    /**
+     * @param PaymentMethod $paymentMethodHelper
+     * @param Logger $monduFileLogger
+     * @param ContextHelper $contextHelper
+     * @param \Mondu\Mondu\Helpers\Log $monduLogger
+     */
+    public function __construct(
+        PaymentMethod $paymentMethodHelper,
+        Logger $monduFileLogger,
+        ContextHelper $contextHelper,
+        \Mondu\Mondu\Helpers\Log $monduLogger
+    ) {
+        parent::__construct($paymentMethodHelper, $monduFileLogger, $contextHelper);
+        $this->monduLogger = $monduLogger;
+    }
+
+    /**
+     * Execute
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function _execute(Observer $observer)
+    {
+        $order = $observer->getEvent()->getOrder();
+        $monduUuid = $order->getMonduReferenceId();
+        $orderData = $this->monduLogger->getTransactionByOrderUid($monduUuid);
+
+        if (isset($orderData['mondu_state']) && $orderData['mondu_state'] === 'pending') {
+            $order->addStatusHistoryComment(
+                __('Mondu: Order Status changed to Payment Review because it needs manual confirmation')
+            );
+            $order->setState(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW);
+            $order->setStatus(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW);
+            $order->save();
+        }
+    }
+}

--- a/Observer/Config/Save.php
+++ b/Observer/Config/Save.php
@@ -31,8 +31,7 @@ class Save implements ObserverInterface
     private $subscriptions = [
         'order/confirmed',
         'order/declined',
-        'order/pending',
-        'order/canceled'
+        'order/pending'
     ];
 
     /**
@@ -92,11 +91,6 @@ class Save implements ObserverInterface
                     $this->requestFactory
                        ->create(RequestFactory::WEBHOOKS_REQUEST_METHOD)
                        ->setTopic('order/declined')
-                       ->process();
-
-                    $this->requestFactory
-                       ->create(RequestFactory::WEBHOOKS_REQUEST_METHOD)
-                       ->setTopic('order/canceled')
                        ->process();
 
                     $this->monduConfig->clearConfigurationCache();

--- a/Observer/CreateOrder.php
+++ b/Observer/CreateOrder.php
@@ -150,7 +150,6 @@ class CreateOrder extends MonduObserver
 
             $order->setData('mondu_reference_id', $orderUid);
             $order->addStatusHistoryComment(__('Mondu: order id %1', $orderData['uuid']));
-            $order = $this->assignMagentoStatus($order, $orderData['state']);
             $order->save();
             $this->monduFileLogger->info('Saved the order in Magento ', ['orderNumber' => $order->getIncrementId()]);
 
@@ -183,20 +182,5 @@ class CreateOrder extends MonduObserver
             return $authorizationData['order'];
         }
         return $orderData;
-    }
-
-    /**
-     * AssignMagentoStatus
-     *
-     * @param Order $order
-     * @param string $monduOrderState
-     * @return Order
-     */
-    protected function assignMagentoStatus($order, $monduOrderState)
-    {
-        if ($monduOrderState === 'pending') {
-            $order->setStatus(Order::STATE_PAYMENT_REVIEW);
-        }
-        return $order;
     }
 }

--- a/Observer/CreateOrder.php
+++ b/Observer/CreateOrder.php
@@ -150,7 +150,7 @@ class CreateOrder extends MonduObserver
 
             $order->setData('mondu_reference_id', $orderUid);
             $order->addStatusHistoryComment(__('Mondu: order id %1', $orderData['uuid']));
-
+            $order = $this->assignMagentoStatus($order, $orderData['state']);
             $order->save();
             $this->monduFileLogger->info('Saved the order in Magento ', ['orderNumber' => $order->getIncrementId()]);
 
@@ -183,5 +183,20 @@ class CreateOrder extends MonduObserver
             return $authorizationData['order'];
         }
         return $orderData;
+    }
+
+    /**
+     * AssignMagentoStatus
+     *
+     * @param Order $order
+     * @param string $monduOrderState
+     * @return Order
+     */
+    protected function assignMagentoStatus($order, $monduOrderState)
+    {
+        if ($monduOrderState === 'pending') {
+            $order->setStatus(Order::STATE_PAYMENT_REVIEW);
+        }
+        return $order;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "mondu_gmbh/magento2-payment",
   "description": "Mondu payment method for magento 2",
   "type": "magento2-module",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": [
     "MIT"
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,19 @@ services:
     ports:
       - 80:8080
     environment:
+      - BITNAMI_DEBUG=true
       - MAGENTO_HOST=localhost
       - MAGENTO_MODE=developer
       - MAGENTO_DATABASE_HOST=mariadb
       - MAGENTO_DATABASE_PORT_NUMBER=3306
       - MAGENTO_DATABASE_USER=bn_magento
       - MAGENTO_DATABASE_NAME=bitnami_magento
+      - MAGENTO_ELASTICSEARCH_HOST=elasticsearch
+      - MAGENTO_ELASTICSEARCH_PORT_NUMBER=9200
       - MAGENTO_USERNAME=mondu
-      - MAGENTO_PASSWORD=mondu
+      - MAGENTO_PASSWORD=mondu123
+      - MAGENTO_EMAIL=mondu@mondu.ai
       - ALLOW_EMPTY_PASSWORD=yes
-      - ELASTICSEARCH_HOST=elasticsearch
-      - ELASTICSEARCH_PORT_NUMBER=9200
       - PHP_MEMORY_LIMIT=5120M
     volumes:
       - magento_data:/bitnami/magento

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -5,6 +5,9 @@
     <event name="sales_order_place_before">
         <observer name="sales_order_place_before_mondu" instance="Mondu\Mondu\Observer\CreateOrder"/>
     </event>
+    <event name="sales_order_place_after">
+        <observer name="sales_order_place_after_mondu" instance="Mondu\Mondu\Observer\AfterPlaceOrder"/>
+    </event>
 
     <event name="order_cancel_after">
         <observer name="mondu_order_cancel_after"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mondu_Mondu" setup_version="2.2.1">
+    <module name="Mondu_Mondu" setup_version="2.2.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
## Description

Remove inexistent order canceled webhook. 

Change Magento order status to payment_review if it's in a pending state.

## Release information

Release: p
Tickets: PT-537

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works
