### PR TITLE
[PT-728] Order state processing when order is confirmed.

### DIFF
--- a/Observer/AfterPlaceOrder.php
+++ b/Observer/AfterPlaceOrder.php
@@ -2,6 +2,7 @@
 namespace Mondu\Mondu\Observer;
 
 use Magento\Framework\Event\Observer;
+use Magento\Sales\Model\Order;
 use Mondu\Mondu\Helpers\ContextHelper;
 use Mondu\Mondu\Helpers\Logger\Logger;
 use Mondu\Mondu\Helpers\PaymentMethod;
@@ -45,8 +46,12 @@ class AfterPlaceOrder extends MonduObserver
             $order->addStatusHistoryComment(
                 __('Mondu: Order Status changed to Payment Review because it needs manual confirmation')
             );
-            $order->setState(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW);
-            $order->setStatus(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW);
+            $order->setState(Order::STATE_PAYMENT_REVIEW);
+            $order->setStatus(Order::STATE_PAYMENT_REVIEW);
+            $order->save();
+        } else {
+            $order->setState(Order::STATE_PROCESSING);
+            $order->setStatus(Order::STATE_PROCESSING);
             $order->save();
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "mondu_gmbh/magento2-payment",
   "description": "Mondu payment method for magento 2",
   "type": "magento2-module",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "license": [
     "MIT"
   ],

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -103,11 +103,6 @@
                         <label>Installments by Invoice Description</label>
                         <config_path>payment/monduinstallmentbyinvoice/description</config_path>
                     </field>
-                    <field id="order_status" translate="label" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" canRestore="1">
-                        <label>New Order Status</label>
-                        <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
-                        <config_path>payment/mondu/order_status</config_path>
-                    </field>
                     <field id="allowspecific" translate="label" type="allowspecific" sortOrder="14" showInDefault="9"
                            showInWebsite="1" showInStore="1">
                         <label>Payment From Applicable Countries</label>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mondu_Mondu" setup_version="2.2.2">
+    <module name="Mondu_Mondu" setup_version="2.3.0">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
## Description

1. Set order state and status to processing if the order is confirmed on Mondu side.
2. Remove new order state configuration.

Fixes # (issue)

## Release information

Please **specify** p/m/M/- for patch/minor/major/none
Release: m
Tickets: PT-728

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
