### PR TITLE
Fixes that data patches would not properly resolve table names

### DIFF
--- a/Setup/Patch/Data/CronJobPatch.php
+++ b/Setup/Patch/Data/CronJobPatch.php
@@ -27,14 +27,15 @@ class CronJobPatch implements DataPatchInterface
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $previousValue = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM core_config_data WHERE path = "payment/mondu/require_invoice"');
+        $tableName = $this->moduleDataSetup->getTable('core_config_data');
+        $previousValue = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM ' . $tableName . ' WHERE `path` = "payment/mondu/require_invoice"');
 
         if ($previousValue) {
             $this->moduleDataSetup
                 ->getConnection()
-                ->delete('core_config_data', ['path = "payment/mondu/cron_require_invoice"']);
+                ->delete($tableName, ['path = "payment/mondu/cron_require_invoice"']);
 
-            $this->moduleDataSetup->getConnection()->insert('core_config_data', [
+            $this->moduleDataSetup->getConnection()->insert($tableName, [
                 'scope' => 'default',
                 'scope_id' => 0,
                 'path' => 'payment/mondu/cron_require_invoice',

--- a/Setup/Patch/Data/WebhookSecretPatch.php
+++ b/Setup/Patch/Data/WebhookSecretPatch.php
@@ -24,20 +24,21 @@ class WebhookSecretPatch implements DataPatchInterface
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $liveWebhookSecret = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM core_config_data WHERE path = "payment/mondu/live_webhook_secret"');
-        $sandboxWebhookSecret = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM core_config_data WHERE path = "payment/mondu/sandbox_webhook_secret"');
+        $tableName = $this->moduleDataSetup->getTable('core_config_data');
+        $liveWebhookSecret = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM ' . $tableName . ' WHERE `path` = "payment/mondu/live_webhook_secret"');
+        $sandboxWebhookSecret = $this->moduleDataSetup->getConnection()->fetchOne('SELECT `value` FROM ' . $tableName . ' WHERE `path` = "payment/mondu/sandbox_webhook_secret"');
 
-        $this->moduleDataSetup->getConnection()->delete('core_config_data', ['path = "payment/mondu/sandbox_webhook_secret"']);
-        $this->moduleDataSetup->getConnection()->delete('core_config_data', ['path = "payment/mondu/live_webhook_secret"']);
+        $this->moduleDataSetup->getConnection()->delete($tableName, ['path = "payment/mondu/sandbox_webhook_secret"']);
+        $this->moduleDataSetup->getConnection()->delete($tableName, ['path = "payment/mondu/live_webhook_secret"']);
 
-        $this->moduleDataSetup->getConnection()->insert('core_config_data', [
+        $this->moduleDataSetup->getConnection()->insert($tableName, [
             'scope' => 'default',
             'scope_id' => 0,
             'path' => 'payment/mondu/sandbox_webhook_secret',
             'value' => $sandboxWebhookSecret,
         ]);
 
-        $this->moduleDataSetup->getConnection()->insert('core_config_data', [
+        $this->moduleDataSetup->getConnection()->insert($tableName, [
             'scope' => 'default',
             'scope_id' => 0,
             'path' => 'payment/mondu/live_webhook_secret',

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -11,25 +11,25 @@
                        showInStore="1">
                     <label>Api Configuration</label>
                     <field id="mondu_key" translate="label" type="obscure" sortOrder="30" showInDefault="1"
-                           showInWebsite="1" showInStore="1">
+                           showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Api key</label>
                         <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                         <config_path>payment/mondu/mondu_key</config_path>
                     </field>
                     <field id="mondu_send_lines" translate="label" type="select" sortOrder="31" showInDefault="1"
-                           showInWebsite="0" showInStore="0">
+                           showInWebsite="0" showInStore="0" canRestore="1">
                         <label>Send order line items</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondu/send_lines</config_path>
                     </field>
                     <field id="mondu_require_invoice" translate="label" type="select" sortOrder="32" showInDefault="1"
-                           showInWebsite="0" showInStore="0">
+                           showInWebsite="0" showInStore="0" canRestore="1">
                         <label>Require invoice for shipment</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondu/require_invoice</config_path>
                     </field>
                     <field id="sandbox" translate="label" type="select" sortOrder="85" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Sandbox mode</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondu/sandbox</config_path>
@@ -40,112 +40,112 @@
 
                     <label>General configuration</label>
                     <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enable Bank Transfer</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondu/active</config_path>
                     </field>
                     <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Bank Transfer Title</label>
                         <config_path>payment/mondu/title</config_path>
                     </field>
                     <field id="description" translate="label" type="textarea" sortOrder="3" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Bank Transfer Description</label>
                         <config_path>payment/mondu/description</config_path>
                     </field>
                     <field id="activesepa" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enable SEPA Direct Debit</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondusepa/active</config_path>
                     </field>
                     <field id="sepa_title" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>SEPA Direct Debit Title</label>
                         <config_path>payment/mondusepa/title</config_path>
                     </field>
                     <field id="sepa_description" translate="label" type="textarea" sortOrder="6" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>SEPA Direct Debit Description</label>
                         <config_path>payment/mondusepa/description</config_path>
                     </field>
                     <field id="activeinstallment" translate="label" type="select" sortOrder="7" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enable Split Payments</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/monduinstallment/active</config_path>
                     </field>
                     <field id="installment_title" translate="label" type="text" sortOrder="8" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Split Payments Title</label>
                         <config_path>payment/monduinstallment/title</config_path>
                     </field>
                     <field id="installment_description" translate="label" type="textarea" sortOrder="9" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Split Payments Description</label>
                         <config_path>payment/monduinstallment/description</config_path>
                     </field>
                     <field id="activeinstallmentbyinvoice" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enable Installments By Invoice</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/monduinstallmentbyinvoice/active</config_path>
                     </field>
                     <field id="installment_by_invoice_title" translate="label" type="text" sortOrder="11" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Installments by Invoice Title</label>
                         <config_path>payment/monduinstallmentbyinvoice/title</config_path>
                     </field>
                     <field id="installment_by_invoice_description" translate="label" type="textarea" sortOrder="12" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Installments by Invoice Description</label>
                         <config_path>payment/monduinstallmentbyinvoice/description</config_path>
                     </field>
                     <field id="allowspecific" translate="label" type="allowspecific" sortOrder="14" showInDefault="9"
-                           showInWebsite="1" showInStore="1">
+                           showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Payment From Applicable Countries</label>
                         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                         <config_path>payment/mondu/allowspecific</config_path>
                     </field>
                     <field id="specificcountry" translate="label" type="multiselect" sortOrder="15" showInDefault="1"
-                           showInWebsite="1" showInStore="1">
+                           showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Payment From Specific Countries</label>
                         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                         <config_path>payment/mondu/specificcountry</config_path>
                     </field>
 
                     <field id="mondusortorder" translate="label" type="text" sortOrder="16" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Bank Transfer Sort Order</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondu/sort_order</config_path>
                     </field>
 
                     <field id="mondusepasortorder" translate="label" type="text" sortOrder="17" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>SEPA Direct Debit Sort Order</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mondusepa/sort_order</config_path>
                     </field>
 
                     <field id="monduinstallmentsortorder" translate="label" type="text" sortOrder="18" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Split Payments Sort Order</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/monduinstallment/sort_order</config_path>
                     </field>
 
                     <field id="monduinstallmentbyinvoicesortorder" translate="label" type="text" sortOrder="19" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Installments By Invoice Sort Order</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/monduinstallmentbyinvoice/sort_order</config_path>
                     </field>
 
                     <field id="debug" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enable Logs</label>
                         <config_path>payment/mondu/debug</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -156,19 +156,21 @@
                     <label>Cron configuration</label>
 
                     <field id="cron" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0"
-                           showInStore="0">
+                           showInStore="0" canRestore="1">
                         <label>Enable Cron job for sending invoices to Mondu</label>
                         <config_path>payment/mondu/cron</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
 
-                    <field id="monducron_status" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <field id="monducron_status" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0"
+                           showInStore="0" canRestore="1">
                         <label>Order status in which order will be processed by the Cron job</label>
                         <config_path>payment/mondu/cron_status</config_path>
                         <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
                     </field>
 
-                    <field id="monducron_requireinvoice" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <field id="monducron_requireinvoice" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0"
+                           showInStore="0" canRestore="1">
                         <label>Require Invoice document for processing orders</label>
                         <config_path>payment/mondu/cron_require_invoice</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
## Description

When a table prefix is set in a Magento installation, applying the data patches during `bin/magento setup:upgrade` abort the process with an error stating that the table `core_config_data` cannot be found.

As a bonus configuration entries are now restorable, thus preventing redundant data in `core_config_data`.

## Release information

Please **specify** p/m/M/- for patch/minor/major/none
Release: p
Tickets: n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [] I have added tests that prove my fix is effective or that my feature works
