### PR TITLE
PT-4290: Pluggable invoice PDF renderer (3rd-party PDF template support)

### DIFF
--- a/Controller/Index/Invoice.php
+++ b/Controller/Index/Invoice.php
@@ -14,15 +14,15 @@ use Magento\Framework\Exception\NotFoundException;
 use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Sales\Model\Order\Pdf\Invoice as PdfInvoiceModel;
 use Magento\Store\Model\App\Emulation as AppEmulation;
+use Mondu\Mondu\Model\Pdf\InvoicePdfRendererInterface;
 use Zend_Pdf_Exception;
 
 class Invoice implements ActionInterface
 {
     /**
      * @param OrderRepositoryInterface $orderRepository
-     * @param PdfInvoiceModel $pdfInvoiceModel
+     * @param InvoicePdfRendererInterface $pdfRenderer
      * @param RawFactory $resultRawFactory
      * @param RequestInterface $request
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
@@ -30,7 +30,7 @@ class Invoice implements ActionInterface
      */
     public function __construct(
         private readonly OrderRepositoryInterface $orderRepository,
-        private readonly PdfInvoiceModel $pdfInvoiceModel,
+        private readonly InvoicePdfRendererInterface $pdfRenderer,
         private readonly RawFactory $resultRawFactory,
         private readonly RequestInterface $request,
         private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
@@ -81,10 +81,17 @@ class Invoice implements ActionInterface
      * Renders the invoice PDF under the order's store front-end environment.
      *
      * Emulating the order's store view loads that store's configuration and
-     * design/theme, so merchant-specific invoice template customizations
-     * (e.g. Swissup PDF Templates) are applied instead of Magento's default
-     * layout. Mondu fetches this URL server-side without a session, so without
-     * emulation the default store scope is used and custom templates are skipped.
+     * design/theme, so merchant-specific invoice template customizations are
+     * applied instead of Magento's default layout. Mondu fetches this URL
+     * server-side without a session, so without emulation the default store
+     * scope is used and custom templates are skipped.
+     *
+     * The actual rendering is delegated to the configured
+     * {@see InvoicePdfRendererInterface}: by default Magento's core PDF model,
+     * or a 3rd-party engine (e.g. Swissup PDF Invoice) when its provider reports
+     * itself available. This ensures the PDF sent to Mondu matches the invoice
+     * the merchant actually produces, even when the PDF module bypasses the core
+     * model and uses its own rendering engine.
      *
      * @param OrderInterface $order
      * @param InvoiceInterface $invoice
@@ -100,7 +107,7 @@ class Invoice implements ActionInterface
         );
 
         try {
-            return $this->pdfInvoiceModel->getPdf([$invoice])->render();
+            return $this->pdfRenderer->render($order, $invoice);
         } finally {
             $this->appEmulation->stopEnvironmentEmulation();
         }

--- a/Model/Pdf/CompositeInvoicePdfRenderer.php
+++ b/Model/Pdf/CompositeInvoicePdfRenderer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mondu\Mondu\Model\Pdf;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Delegates rendering to the first available optional provider (e.g. Swissup),
+ * falling back to the default core renderer. Any provider failure is logged and
+ * degrades gracefully to the default renderer.
+ */
+class CompositeInvoicePdfRenderer implements InvoicePdfRendererInterface
+{
+    /**
+     * @param InvoicePdfRendererInterface $defaultRenderer
+     * @param LoggerInterface $logger
+     * @param InvoicePdfProviderInterface[] $providers
+     */
+    public function __construct(
+        private readonly InvoicePdfRendererInterface $defaultRenderer,
+        private readonly LoggerInterface $logger,
+        private readonly array $providers = []
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(OrderInterface $order, InvoiceInterface $invoice): string
+    {
+        foreach ($this->providers as $provider) {
+            if (!$provider instanceof InvoicePdfProviderInterface) {
+                continue;
+            }
+
+            try {
+                if ($provider->isAvailable($order, $invoice)) {
+                    return $provider->render($order, $invoice);
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Mondu: invoice PDF provider failed, falling back to default renderer: '
+                    . $e->getMessage()
+                );
+            }
+        }
+
+        return $this->defaultRenderer->render($order, $invoice);
+    }
+}

--- a/Model/Pdf/CoreInvoicePdfRenderer.php
+++ b/Model/Pdf/CoreInvoicePdfRenderer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mondu\Mondu\Model\Pdf;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Pdf\Invoice as PdfInvoiceModel;
+
+/**
+ * Default renderer using Magento's core invoice PDF model. Store-scope/theme
+ * emulation is handled by the caller (Controller\Index\Invoice).
+ */
+class CoreInvoicePdfRenderer implements InvoicePdfRendererInterface
+{
+    /**
+     * @param PdfInvoiceModel $pdfInvoiceModel
+     */
+    public function __construct(
+        private readonly PdfInvoiceModel $pdfInvoiceModel
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Zend_Pdf_Exception
+     */
+    public function render(OrderInterface $order, InvoiceInterface $invoice): string
+    {
+        return $this->pdfInvoiceModel->getPdf([$invoice])->render();
+    }
+}

--- a/Model/Pdf/InvoicePdfProviderInterface.php
+++ b/Model/Pdf/InvoicePdfProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mondu\Mondu\Model\Pdf;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Optional invoice PDF renderer that only applies when its backing 3rd-party
+ * module is installed and enabled. The composite renderer asks isAvailable()
+ * before delegating and falls back to the default renderer otherwise.
+ */
+interface InvoicePdfProviderInterface extends InvoicePdfRendererInterface
+{
+    /**
+     * @param OrderInterface $order
+     * @param InvoiceInterface $invoice
+     * @return bool
+     */
+    public function isAvailable(OrderInterface $order, InvoiceInterface $invoice): bool;
+}

--- a/Model/Pdf/InvoicePdfRendererInterface.php
+++ b/Model/Pdf/InvoicePdfRendererInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mondu\Mondu\Model\Pdf;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Renders an invoice into PDF bytes for the invoice_url Mondu fetches.
+ *
+ * Introduced so the renderer is pluggable: 3rd-party PDF template modules that
+ * do not extend Magento's core PDF model (and use their own rendering engine,
+ * e.g. Swissup PDF Invoice) can provide their own implementation instead of
+ * being bypassed by a hard-coded core-model call.
+ */
+interface InvoicePdfRendererInterface
+{
+    /**
+     * @param OrderInterface $order
+     * @param InvoiceInterface $invoice
+     * @return string Raw PDF content
+     */
+    public function render(OrderInterface $order, InvoiceInterface $invoice): string;
+}

--- a/Model/Pdf/SwissupInvoicePdfRenderer.php
+++ b/Model/Pdf/SwissupInvoicePdfRenderer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mondu\Mondu\Model\Pdf;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Renders the invoice PDF through Swissup PDF Invoice (swissup/module-pdf-invoice)
+ * when that module is installed and enabled.
+ *
+ * Swissup does not extend Magento\Sales\Model\Order\Pdf\Invoice: it plugs into the
+ * print controllers and renders with its own mpdf engine (Swissup\PdfInvoice\Model\Pdf),
+ * so calling the core model directly bypasses the merchant's template. This adapter
+ * invokes Swissup's own model to produce the same PDF the merchant sees.
+ *
+ * Swissup classes are referenced only by string / class_exists and instantiated via
+ * the ObjectManager, so the Mondu module keeps no hard (composer) dependency on Swissup.
+ */
+class SwissupInvoicePdfRenderer implements InvoicePdfProviderInterface
+{
+    private const PDF_MODEL = 'Swissup\\PdfInvoice\\Model\\Pdf';
+    private const HELPER = 'Swissup\\PdfInvoice\\Helper\\Data';
+    private const TEMPLATE_TYPE_INVOICE = 'invoice';
+    private const OUTPUT_STRING_RETURN = 'S';
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(
+        private readonly ObjectManagerInterface $objectManager
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAvailable(OrderInterface $order, InvoiceInterface $invoice): bool
+    {
+        if (!class_exists(self::PDF_MODEL) || !class_exists(self::HELPER)) {
+            return false;
+        }
+
+        try {
+            $helper = $this->objectManager->get(self::HELPER);
+            if (method_exists($helper, 'isEnabled') && !$helper->isEnabled()) {
+                return false;
+            }
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(OrderInterface $order, InvoiceInterface $invoice): string
+    {
+        $pdf = $this->objectManager->create(self::PDF_MODEL);
+        $pdf->setTemplateType(self::TEMPLATE_TYPE_INVOICE);
+        $pdf->setEntityId($invoice->getId());
+
+        $content = $pdf->download(self::OUTPUT_STRING_RETURN);
+
+        if (!is_string($content) || $content === '') {
+            throw new \RuntimeException('Swissup PDF Invoice returned empty content');
+        }
+
+        return $content;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mondu_gmbh/magento2-payment",
     "description": "Mondu payment method for magento 2",
     "type": "magento2-module",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "license": "MIT",
     "require": {
         "php": ">=8.1",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -53,4 +53,14 @@
             <argument name="monduFileLogger" xsi:type="object">Mondu\Mondu\Helpers\Logger\Logger</argument>
         </arguments>
     </type>
+    <preference for="Mondu\Mondu\Model\Pdf\InvoicePdfRendererInterface"
+                type="Mondu\Mondu\Model\Pdf\CompositeInvoicePdfRenderer"/>
+    <type name="Mondu\Mondu\Model\Pdf\CompositeInvoicePdfRenderer">
+        <arguments>
+            <argument name="defaultRenderer" xsi:type="object">Mondu\Mondu\Model\Pdf\CoreInvoicePdfRenderer</argument>
+            <argument name="providers" xsi:type="array">
+                <item name="swissup" xsi:type="object">Mondu\Mondu\Model\Pdf\SwissupInvoicePdfRenderer</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mondu_Mondu" setup_version="2.9.0">
+    <module name="Mondu_Mondu" setup_version="2.9.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
## Description

Follow-up on the invoice PDF sent to Mondu. The controller that serves the invoice PDF URL rendered exclusively via Magento's core `Magento\Sales\Model\Order\Pdf\Invoice` model. 3rd-party PDF template modules that do not extend the core model and use their own rendering engine were therefore bypassed, so Mondu received the default Magento PDF instead of the merchant's customized invoice.

This makes the renderer pluggable:

- `Model/Pdf/InvoicePdfRendererInterface` — render contract.
- `Model/Pdf/InvoicePdfProviderInterface` — optional provider (`isAvailable()`).
- `Model/Pdf/CoreInvoicePdfRenderer` — default (core model, unchanged behavior).
- `Model/Pdf/SwissupInvoicePdfRenderer` — adapter that renders via the 3rd-party engine when installed and enabled; referenced only via `class_exists`/ObjectManager, so no composer dependency is added.
- `Model/Pdf/CompositeInvoicePdfRenderer` — uses the first available provider, otherwise falls back to the default; provider errors are logged and degrade gracefully.
- `Controller/Index/Invoice.php` now delegates to the interface (store emulation preserved).

Fully backward compatible: with no 3rd-party PDF module (or it disabled), behavior is identical to the current core rendering.

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-4290

## Release information

Release: p
Tickets: PT-4290

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings